### PR TITLE
[Investigation] The first call to SDL_RenderPresent is very slow - almost 1.5 seconds#28

### DIFF
--- a/maze-roamer/main.cpp
+++ b/maze-roamer/main.cpp
@@ -10,8 +10,8 @@ int main(int argc, char* argv[]) {
     SDL_Init(SDL_INIT_VIDEO);
 
     SDL_Window* window;
-    window = SDL_CreateWindow("Maze Roamer | Score: 0", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 640, 480, SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL);
-    
+    window = SDL_CreateWindow("Maze Roamer | Score: 0", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 832, 416, SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL);
+
     if (window == NULL) {
         std::cout << "Could not create window: " << SDL_GetError() << '\n';
         return 1;
@@ -20,7 +20,6 @@ int main(int argc, char* argv[]) {
     SDL_Renderer* renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
 
     maze m("level01.txt", renderer, window);
-    SDL_SetWindowSize(window, m.get_width(), m.get_height());
 
     auto started = std::chrono::high_resolution_clock::now();
     m.initialize();


### PR DESCRIPTION
[[Investigation] The first call to SDL_RenderPresent is very slow - almost 1.5 seconds#28](https://github.com/annoviko/maze-roamer/issues/28)

SDL_SetWindowSize removed